### PR TITLE
Fix error parsing in case of bad request

### DIFF
--- a/walmart/walmart.py
+++ b/walmart/walmart.py
@@ -121,7 +121,7 @@ class Walmart(object):
                     ))
                 elif response.status_code == 400:
                     data = response.json()
-                    if data["error"][0]["code"] == \
+                    if "error" in data and data["error"][0]["code"] == \
                             "INVALID_TOKEN.GMP_GATEWAY_API":
                         # Refresh the token as the current token has expired
                         self.authenticate()


### PR DESCRIPTION
Some reponses from bad requests can have a different data
structure like: {'errors': {'error': [{....]}}}